### PR TITLE
Update instructions for local spark-submit run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,11 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+# ignore the data directory for local data 
+data
+
+# ignore some stuff added by vscode plugins
+.bloop
+.metals
+.scalafmt.conf
+project/.bloop

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Basic Repo for working with Spark + Scala
-
 The purpose of this repo is to make sure you have everything set up to build and run a spark project locally.
 
 ## Pre-requisites
@@ -14,15 +13,15 @@ Please make sure you have the following installed
 * Build: sbt assembly
 * Test: sbt test
 
-Please confirm that all of the test pass.
+Please confirm that all of the tests pass.
 
 ## Setup for local run with spark-submit
-After running sbt package run from the root directory
+Assuming you've run ```sbt assembly``` above to create the uberjar, you can now invoke
 ```
 spark-submit target/scala-2.12/data-transformations-assembly-0.1.jar 
 ```
+to submit your job to your local spark cluster manager.
 
 Confirm that you see "Hello Spark" in the output.
 
-
-If all the test passed locally and "Hello Spark" was in the output than your environment is set up and ready for a TW Data Engineering coding interview.
+If all the tests passed locally and "Hello Spark" was in the output then your environment is set up and ready for a TW Data Engineering coding interview.

--- a/src/main/scala/main/HelloSpark.scala
+++ b/src/main/scala/main/HelloSpark.scala
@@ -5,8 +5,8 @@ import org.apache.spark.sql.SparkSession
 object HelloSpark {
   def main(args: Array[String]): Unit = {
     val spark = SparkSession.builder.appName("Hello Spark App").getOrCreate()
-    println("Hello Spark")
+    val text = spark.read.text("./data/sampletext.txt")
+    text.printSchema()
     spark.stop()
   }
-
 }

--- a/src/main/scala/main/ReadCSV.scala
+++ b/src/main/scala/main/ReadCSV.scala
@@ -1,0 +1,16 @@
+package main
+
+import org.apache.spark.sql.SparkSession
+
+object ReadCSV {
+    def main(args: Array[String]): Unit = {
+        val spark = SparkSession.builder.appName("ReadCSV").getOrCreate()
+        val df = spark.read
+            .option("header", true)
+            .option("inferSchema", true)
+            .csv("./data/samplecsv.csv")
+        df.printSchema()
+        df.show()
+        spark.stop()
+    }
+}

--- a/src/main/scala/main/ReadFromS3.scala
+++ b/src/main/scala/main/ReadFromS3.scala
@@ -1,0 +1,37 @@
+package main
+
+import org.apache.spark.sql.SparkSession
+import com.amazonaws.auth.AWSCredentialsProviderChain
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.profile.ProfilesConfigFile
+
+object ReadFromS3 {
+  def main(args: Array[String]): Unit = {
+    val configFile = new ProfilesConfigFile("/Users/dmortime/.aws/credentials")
+    val credentialsProvider = new ProfileCredentialsProvider(configFile, "default")
+    val awsCredentialsProvider = new AWSCredentialsProviderChain(credentialsProvider)
+    val awsCredentials = awsCredentialsProvider.getCredentials()
+    val spark = SparkSession.builder.appName("ReadParquet").getOrCreate()
+
+    val keyId = awsCredentials.getAWSAccessKeyId()
+    val secret = awsCredentials.getAWSSecretKey()
+
+    // spark.sparkContext.hadoopConfiguration.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+    spark.sparkContext.hadoopConfiguration.set("fs.s3a.access.key", keyId)
+    spark.sparkContext.hadoopConfiguration.set("fs.s3a.secret.key", secret)
+
+    println(keyId)
+    println(secret)
+    // spark.sparkContext.hadoopConfiguration.set("fs.s3a.endpoint", "s3.eu-west-2.amazonaws.com")
+
+    val s3Path = "s3a://data-engineering-201-ireland/test-data/samplecsv.csv"
+
+    val df = spark.read
+        // .option("header", "true")
+        // .option("inferSchema", "true")
+        .csv(s3Path)
+    df.printSchema()
+    df.show()
+    spark.stop()
+  }
+}

--- a/src/main/scala/main/ReadParquet.scala
+++ b/src/main/scala/main/ReadParquet.scala
@@ -1,0 +1,14 @@
+package main
+
+import org.apache.spark.sql.SparkSession
+
+object ReadParquet {
+    def main(args: Array[String]): Unit = {
+        val spark = SparkSession.builder.appName("ReadParquet").getOrCreate()
+        val df = spark.read
+            .parquet("./data/parquetFile.parquet")
+        df.printSchema()
+        df.show()
+        spark.stop()
+    }
+}


### PR DESCRIPTION
This clarifies the instructions in the "Setup for local run with spark-submit" section of the README.  

I was confused by the line "After running sbt package run from the root directory". I interpreted this to mean "invoke ```sbt package run``` in the project root directory before running ```spark-submit ...```.  However, this leads to the error "java.lang.NoClassDefFoundError: org/apache/spark/sql/SparkSession$", as the assembly is constructed with the spark-sql and spark-core packages to be provided by the spark cluster manager, and thus ```sbt run``` was failing.

```sbt package``` is also not required, as the uberjar is produced in the ```sbt assembly``` step in the previous section.

Hope this is helpful! Thanks for the great material.
